### PR TITLE
fix bug concerning files with umlaut characters

### DIFF
--- a/R/page_uploadData.R
+++ b/R/page_uploadData.R
@@ -94,7 +94,11 @@ uploadDataset <- function(input, project, basePath = BASE_PATH){
   fileName <- file$name
   filePath <- file$datapath
   
-  data <- read_csv(filePath)
+  # files may not be encoded with UTF-8. Guess the encoding here to prevent errors later on
+  fileEncoding <- guess_encoding(path)[[1,1]]
+  
+  data <- read_csv(filePath, locale = locale(encoding = fileEncoding))
+  
   uniqueIdentifier <- getUniqueIdentifer(data)
   optionsPath <- file.path(basePath, "processingOptions", uniqueIdentifier)
   


### PR DESCRIPTION
closes #52 

The bug is related to the input file not being UTF-8 encoded. Solution: Guess file encoding on file upload.