### PR TITLE
Average over range of injections

### DIFF
--- a/R/helpers_pageProcessDataPlots.R
+++ b/R/helpers_pageProcessDataPlots.R
@@ -176,7 +176,6 @@ pageProcessDataPlots <- function(input, output, session, id,
       )
     })
     
-    nInj <- # TODO
     # use the calibrated data, because it has the column "block"
     data <- getH2OMeanAndStdDev(rv$dataToPlot$calibrated, nInj())
       
@@ -298,10 +297,17 @@ getH2OMeanAndStdDev <- function(data, nInj){
       group_by(`Identifier 1`, block) %>% 
       summarise(H2OMean = mean(H2O_Mean), H2OSD = sd(H2O_Mean), Line = min(Line))
   } else {
-    aggregatedData <- data %>%
-      group_by(`Identifier 1`, block) %>% 
-      slice((n()-nInj+1):n()) %>%
-      summarise(H2OMean = mean(H2O_Mean), H2OSD = sd(H2O_Mean), Line = min(Line))
+    nInj <- eval(parse(text = nInj))
+    if (length(nInj) == 1)
+      aggregatedData <- data %>%
+        group_by(`Identifier 1`, block) %>% 
+        slice((n()-nInj+1):n()) %>%
+        summarise(H2OMean = mean(H2O_Mean), H2OSD = sd(H2O_Mean), Line = min(Line))
+    else
+      aggregatedData <- data %>%
+        group_by(`Identifier 1`, block) %>% 
+        slice(nInj) %>%
+        summarise(H2OMean = mean(H2O_Mean), H2OSD = sd(H2O_Mean), Line = min(Line))
   }
   orderedData <- aggregatedData %>%
     arrange(Line) %>%

--- a/R/helpers_processDataWithPiccr.R
+++ b/R/helpers_processDataWithPiccr.R
@@ -3,13 +3,13 @@ library(futile.logger)
 library(piccr)
 
 processDataWithPiccr <- function(datasets, processingOptions, useMemoryCorrection, 
-                                 calibrationFlag, useThreePointCalibration, averageOverLastNInj){
+                                 calibrationFlag, useThreePointCalibration, averageOverInj){
   
   flog.info(str_c("Processing datasets"))
   
   flog.debug("Generating config")
   config <- list(
-    average_over_last_n_inj = averageOverLastNInj,
+    average_over_inj = averageOverInj,
     use_memory_correction = useMemoryCorrection,
     calibration_method = calibrationFlag,
     use_three_point_calibration = useThreePointCalibration

--- a/tests/testthat/testProcess.R
+++ b/tests/testthat/testProcess.R
@@ -28,7 +28,7 @@ test_that("overage over all inj", {
 
   processedData <- processDataWithPiccr(
     datasets, processingOptions, useMemoryCorrection = T, calibrationFlag = 1,
-    useThreePointCalibration = T, averageOverLastNInj = "all")
+    useThreePointCalibration = T, averageOverInj = "all")
 
   expect_length(processedData, 2)
   
@@ -57,7 +57,7 @@ test_that("overage over 2 inj", {
 
   processedData <- processDataWithPiccr(
     datasets, processingOptions, useMemoryCorrection = T, calibrationFlag = 1,
-    useThreePointCalibration = T, averageOverLastNInj = 2)
+    useThreePointCalibration = T, averageOverInj = 2)
 
   expect_length(processedData, 2)
   
@@ -86,11 +86,11 @@ test_that("number of inj to average over matters", {
 
   processedDataTwoInj <- processDataWithPiccr(
     datasets, processingOptions, useMemoryCorrection = T, calibrationFlag = 1,
-    useThreePointCalibration = T, averageOverLastNInj = 2)
+    useThreePointCalibration = T, averageOverInj = 2)
 
   processedDataAllInj <- processDataWithPiccr(
     datasets, processingOptions, useMemoryCorrection = T, calibrationFlag = 1,
-    useThreePointCalibration = T, averageOverLastNInj = "all")
+    useThreePointCalibration = T, averageOverInj = "all")
 
   expect_failure(expect_equal(processedDataAllInj[[1]]$processed, processedDataTwoInj[[1]]$processed))
   expect_failure(expect_equal(processedDataAllInj[[2]]$processed, processedDataTwoInj[[2]]$processed))


### PR DESCRIPTION
closes #64 

This PR introduces the option to average over a range of injections. It should be merged after EarthSystemDiagnostics/piccr#37 is merged.

Note that the tests fail at the moment because the piccr PR has not been merged yet.